### PR TITLE
Use dotnet3.1 in Dockerfile

### DIFF
--- a/leaderboardapp/Dockerfile
+++ b/leaderboardapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -10,7 +10,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "leaderboardapp.dll"]


### PR DESCRIPTION
This Pull Request is intended to resolve `The current .NET SDK does not support targeting .NET Core 3.1.` error like below:

```
$ gcloud builds submit --config k8s/cloudbuild.yaml .
...
BUILD
Already have image (with digest): gcr.io/cloud-builders/docker
Sending build context to Docker daemon  957.4kB
Step 1/10 : FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build-env
3.0: Pulling from dotnet/core/sdk
50e431f79093: Pulling fs layer
... (omit) ...
Step 4/10 : RUN dotnet restore
 Running in 78c0f2e96ad6
/usr/share/dotnet/sdk/3.0.103/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(127,5): error NETSDK1045: The current .NET SDK does not support targeting .NET Core 3.1.  Either target .NET Core 3.0 or lower, or use a version of the .NET SDK that supports .NET Core 3.1. [/app/leaderboardapp.csproj]
The command '/bin/sh -c dotnet restore' returned a non-zero code: 1
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
...
```

A possibly related change is #4, where TargetFramework has been upgraded to netcoreapp3.1.

I've changed tags from `3.0` to `3.1` for following images in the Dockerfile:
* mcr.microsoft.com/dotnet/core/sdk
* mcr.microsoft.com/dotnet/core/aspnet